### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ jobs:
   lint:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Clone the code
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/delta10/access-operator/security/code-scanning/7](https://github.com/delta10/access-operator/security/code-scanning/7)

In general, to fix this issue, add an explicit `permissions` block that grants only the minimal scopes the workflow requires, either at the root of the workflow (applies to all jobs) or inside the specific job. For this lint workflow, it only needs to read repository contents to clone the code and run the linter, so `contents: read` is sufficient.

The best minimal fix here is to add a `permissions` block under the existing `lint` job, right after `runs-on: ubuntu-latest`, with `contents: read`. This keeps the change tightly scoped to this job and does not alter any steps or behavior; it only constrains the `GITHUB_TOKEN` permissions. No additional imports, actions, or steps are needed.

Concretely, edit `.github/workflows/lint.yml` so that:

- Under `jobs.lint`, between lines 10 and 11, insert:
  ```yaml
      permissions:
        contents: read
  ```

This will ensure CodeQL recognizes that `GITHUB_TOKEN` is limited to read-only repository contents for this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
