### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run on Ubuntu


### PR DESCRIPTION
Potential fix for [https://github.com/delta10/access-operator/security/code-scanning/8](https://github.com/delta10/access-operator/security/code-scanning/8)

In general, the fix is to add an explicit `permissions` block to the workflow or to the individual job so that `GITHUB_TOKEN` is restricted to the minimum required scope. For a simple test workflow that only checks out code and runs tests, `contents: read` is usually sufficient, and can be set at the workflow root to apply to all jobs.

The best minimal fix here, without altering functionality, is to add a top-level `permissions` section after the `on:` block, specifying read-only contents access. This will ensure the `test` job runs with a token that can read repository contents but cannot write to the repo or perform other actions. Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `jobs:` section. No additional imports or methods are required since this is just YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
